### PR TITLE
Make notification template configurable

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -11,3 +11,5 @@ command_prefix: "rss"
 # Users who can bypass room permission checks
 admins:
 - "@user:example.com"
+# default post notification template for new subscriptions
+notification_template: "New post in $feed_title: [$title]($link)"

--- a/rss/bot.py
+++ b/rss/bot.py
@@ -41,6 +41,7 @@ class Config(BaseProxyConfig):
         helper.copy("spam_sleep")
         helper.copy("command_prefix")
         helper.copy("admins")
+        helper.copy("notification_template")
 
 
 class BoolArgument(command.Argument):
@@ -71,7 +72,7 @@ class RSSBot(Plugin):
     async def start(self) -> None:
         await super().start()
         self.config.load_and_update()
-        self.db = Database(self.database)
+        self.db = Database(self.database, self.config)
         self.http = self.client.api.session
         self.power_level_cache = {}
         self.poll_task = asyncio.ensure_future(self.poll_feeds(), loop=self.loop)

--- a/rss/db.py
+++ b/rss/db.py
@@ -23,6 +23,7 @@ from sqlalchemy import (Column, String, Integer, DateTime, Text, Boolean, Foreig
 from sqlalchemy.engine.base import Engine
 
 from mautrix.types import UserID, RoomID
+from mautrix.util.config import BaseProxyConfig
 
 Subscription = NamedTuple("Subscription", feed_id=int, room_id=RoomID, user_id=UserID,
                           notification_template=Template, send_notice=bool)
@@ -38,8 +39,9 @@ class Database:
     entry: Table
     version: Table
 
-    def __init__(self, db: Engine) -> None:
+    def __init__(self, db: Engine, config: BaseProxyConfig) -> None:
         self.db = db
+        self.config = config
         metadata = MetaData()
         self.feed = Table("feed", metadata,
                           Column("id", Integer, primary_key=True, autoincrement=True),
@@ -213,7 +215,7 @@ class Database:
     def subscribe(self, feed_id: int, room_id: RoomID, user_id: UserID) -> None:
         self.db.execute(self.subscription.insert().values(
             feed_id=feed_id, room_id=room_id, user_id=user_id,
-            notification_template="New post in $feed_title: [$title]($link)"))
+            notification_template = self.config["notification_template"]))
 
     def unsubscribe(self, feed_id: int, room_id: RoomID) -> None:
         tbl = self.subscription


### PR DESCRIPTION
Move the default notification template to the config so that you can easily change the template for new subscriptions.

fixes #14 