### PR TITLE
Fix compatibility with sqlite3 before v3.35

### DIFF
--- a/rss/db.py
+++ b/rss/db.py
@@ -180,7 +180,7 @@ class DBManager:
     async def create_feed(self, info: Feed) -> Feed:
         q = (
             "INSERT INTO feed (url, title, subtitle, link, next_retry) "
-            "VALUES ($1, $2, $3, $4, $5) RETURNING (id)"
+            "VALUES ($1, $2, $3, $4, $5)"
         )
         info.id = await self.db.fetchval(
             q, info.url, info.title, info.subtitle, info.link, info.next_retry


### PR DESCRIPTION
The language feature `RETURNING` was added to sqlite3 in release v3.35.
See https://www.sqlite.org/draft/lang_returning.html

Thus during the recent switch to `asyncpg` (commit 18ef939a04f) broke compatibility
with sqlite3 before v3.35.
The resulting exception was:
```
sqlite3.OperationalError: near "RETURNING": syntax error
```

Simply removing the `RETURNING (id)` suffix of the query fixes the issues for such an older
versions of sqlite3.
Please note, that the latest stable release of Debian (Bullseye) ships an older version of sqlite3.
The same goes for the latest LTS release of Ubuntu.
Only the latest short-term supported release of Ubuntu (`Impish Indri`) contains a newer version
(supporting `RETURNING`).