### PR TITLE
Stabilize entry IDs

### DIFF
--- a/rss/bot.py
+++ b/rss/bot.py
@@ -279,12 +279,12 @@ class RSSBot(Plugin):
             feed_id=feed_id,
             id=(
                 getattr(entry, "id", None)
+                or getattr(entry, "link", None)
                 or hashlib.sha1(
                     " ".join(
                         [
                             getattr(entry, "title", ""),
                             getattr(entry, "description", ""),
-                            getattr(entry, "link", ""),
                         ]
                     ).encode("utf-8")
                 ).hexdigest()


### PR DESCRIPTION
Thanks for making this! I tried using it to follow [to-rss.xyz/wikipedia/current_events](https://www.to-rss.xyz/wikipedia/) but it sent many duplicate messages. The entries in that feed have no ID—

```xml
<item>
  <title>Current events: 2022-07-13</title>
  <link>https://en.wikipedia.org/wiki/Portal:Current_events/2022_July_13</link>
  <description>[VARIABLE CONTENT]</description>
  <pubDate>Wed, 13 Jul 2022 00:00:00 -0000</pubDate>
  </item>
<item>
```

—and have frequently updated content. Since the fallback ID is [derived from the content](https://github.com/maubot/rss/pull/10), each update is erroneously considered a distinct entry. To handle feeds like this, aggregators typically key entries by just the link, not the content.